### PR TITLE
Modify some displays

### DIFF
--- a/app/controllers/problem_data_manage.php
+++ b/app/controllers/problem_data_manage.php
@@ -471,7 +471,7 @@ EOD
 			DB::update("update problems set hackable = $hackable where id = {$problem['id']}");
 		};
 		$hackable_form->submit_button_config['class_str'] = 'btn btn-warning btn-block';
-		$hackable_form->submit_button_config['text'] = $problem['hackable'] ? '禁止使用hack' : '允许使用hack';
+		$hackable_form->submit_button_config['text'] = $problem['hackable'] ? '禁止使用 hack' : '允许使用 hack';
 		$hackable_form->submit_button_config['smart_confirm'] = '';
 	}
 

--- a/app/locale/basic/en.php
+++ b/app/locale/basic/en.php
@@ -154,7 +154,7 @@ return [
 	'sticky 3' => 'Level 3 sticky',
 	'at tip' => 'You can use "@mike" to refer to mike, and "mike" will be highlighted. If you really wants to type the character "@", please use "@@".',
 	'emoticon tip' => 'Want to use emoticons? Here is the <a href="/blog/791">emoticon guide</a>.',
-	'open source' => 'UOJ on Github',
+	'open source' => 'SOJ OpenSource Project on Github',
 	'system groups' => 'System Groups',
 	'user groups' => 'User Groups',
 	'latest comment' => 'Latest comment'


### PR DESCRIPTION
将“开源项目”的英文从 `UOJ on Github` 修改为 `SOJ OpenSource Project on Github`。

添加了 `禁止使用 hack` `允许使用 hack` 中间的空格。