### PR TITLE
Support recording submissions_history in the database.

### DIFF
--- a/app/.default-config.php
+++ b/app/.default-config.php
@@ -3,7 +3,7 @@ return [
 	'profile' => [
 		'oj-name'  => 'Universal Online Judge',
 		'oj-name-short' => 'UOJ',
-		'oj-version' => '6.1',
+		'oj-version' => '7.0-beta.1',
 		'administrator' => 'root',
 		'admin-email' => 'root@uoj',
 		'qq-group' => '1145141919810',

--- a/app/controllers/contest_inside.php
+++ b/app/controllers/contest_inside.php
@@ -111,7 +111,7 @@
 					}
 					if ($need_rejudge) {
 						$esc_content = DB::escape(json_encode($content));
-						DB::update("update submissions set judge_time = NULL, judger_name = '', result = '', score = NULL, status = 'Waiting Rejudge', content = '$esc_content' where id = {$submission['id']}");
+						DB::update("update submissions set active_version_id = NULL, judge_time = NULL, judger_name = '', result = '', score = NULL, status = 'Waiting Rejudge', content = '$esc_content' where id = {$submission['id']}");
 					}
 				}
 				DB::update("update contests set status = 'testing' where id = {$contest['id']}");

--- a/app/controllers/judge/submit.php
+++ b/app/controllers/judge/submit.php
@@ -26,16 +26,21 @@
 			$content['config'] = $content['first_test_config'];
 			unset($content['first_test_config']);
 			$esc_content = DB::escape(json_encode($content));
-			
-			DB::update("update submissions set status = 'Judged', result = '$esc_result', content = '$esc_content' where id = {$_POST['id']}");
+			DB::update("insert into submissions_history (submission_id, judge_time, judger_name, result, status, result_error, score, used_time, used_memory, status_details) values ({$submissions['id']}, {$submissions['judge_time']}, {$submissions['judger_name']}, '$esc_result', 'Judged', {$submissions['result_error']}, {$submissions['score']}, {$submissions['used_time']}, {$submissions['used_memory']}, {$submissions['status_details']})");
+			$history_id = DB::insert_id();
+			DB::update("update submissions set active_version_id = $history_id, status = 'Judged', result = '$esc_result', content = '$esc_content' where id = {$_POST['id']}");
 		} else {
 			$result = json_decode($_POST['result'], true);
 			$result['details'] = uojTextEncode($result['details']);
 			$esc_result = DB::escape(json_encode($result, JSON_UNESCAPED_UNICODE));
 			if (isset($result["error"])) {
-				DB::update("update submissions set status = '{$result['status']}', result_error = '{$result['error']}', result = '$esc_result', score = null, used_time = null, used_memory = null where id = {$_POST['id']}");
+				DB::update("insert into submissions_history (submission_id, judge_time, judger_name, result, status, result_error, score, used_time, used_memory, status_details) values ({$submissions['id']}, {$submissions['judge_time']}, {$submissions['judger_name']}, '$esc_result', '{$result['status']}', '{$result['error']}', null, null, null, {$submissions['status_details']})");
+				$history_id = DB::insert_id();
+				DB::update("update submissions set active_version_id = $history_id, status = '{$result['status']}', result_error = '{$result['error']}', result = '$esc_result', score = null, used_time = null, used_memory = null where id = {$_POST['id']}");
 			} else {
-				DB::update("update submissions set status = '{$result['status']}', result_error = null, result = '$esc_result', score = {$result['score']}, used_time = {$result['time']}, used_memory = {$result['memory']} where id = {$_POST['id']}");
+				DB::update("insert into submissions_history (submission_id, judge_time, judger_name, result, status, result_error, score, used_time, used_memory, status_details) values ({$submissions['id']}, {$submissions['judge_time']}, {$submissions['judger_name']}, '$esc_result', '{$result['status']}', null, {$result['score']}, {$result['time']}, {$result['memory']}, {$submissions['status_details']})");
+				$history_id = DB::insert_id();
+				DB::update("update submissions set active_version_id = $history_id, status = '{$result['status']}', result_error = null, result = '$esc_result', score = {$result['score']}, used_time = {$result['time']}, used_memory = {$result['memory']} where id = {$_POST['id']}");
 			}
 			
 			if (isset($content['final_test_config'])) {

--- a/app/controllers/judge/submit.php
+++ b/app/controllers/judge/submit.php
@@ -26,7 +26,7 @@
 			$content['config'] = $content['first_test_config'];
 			unset($content['first_test_config']);
 			$esc_content = DB::escape(json_encode($content));
-			DB::update("insert into submissions_history (submission_id, judge_time, judger_name, result, status, result_error, score, used_time, used_memory, status_details) values ({$submissions['id']}, {$submissions['judge_time']}, {$submissions['judger_name']}, '$esc_result', 'Judged', {$submissions['result_error']}, {$submissions['score']}, {$submissions['used_time']}, {$submissions['used_memory']}, {$submissions['status_details']})");
+			DB::insert("insert into submissions_history (submission_id, judge_time, judger_name, result, status, result_error, score, used_time, used_memory, status_details) values ({$submissions['id']}, '{$submissions['judge_time']}', '{$submissions['judger_name']}', '$esc_result', 'Judged', '{$submissions['result_error']}', {$submissions['score']}, {$submissions['used_time']}, {$submissions['used_memory']}, '{$submissions['status_details']}')");
 			$history_id = DB::insert_id();
 			DB::update("update submissions set active_version_id = $history_id, status = 'Judged', result = '$esc_result', content = '$esc_content' where id = {$_POST['id']}");
 		} else {
@@ -34,11 +34,11 @@
 			$result['details'] = uojTextEncode($result['details']);
 			$esc_result = DB::escape(json_encode($result, JSON_UNESCAPED_UNICODE));
 			if (isset($result["error"])) {
-				DB::update("insert into submissions_history (submission_id, judge_time, judger_name, result, status, result_error, score, used_time, used_memory, status_details) values ({$submissions['id']}, {$submissions['judge_time']}, {$submissions['judger_name']}, '$esc_result', '{$result['status']}', '{$result['error']}', null, null, null, {$submissions['status_details']})");
+				DB::insert("insert into submissions_history (submission_id, judge_time, judger_name, result, status, result_error, score, used_time, used_memory, status_details) values ({$submissions['id']}, '{$submissions['judge_time']}', '{$submissions['judger_name']}', '$esc_result', '{$result['status']}', '{$result['error']}', null, null, null, '{$submissions['status_details']}')");
 				$history_id = DB::insert_id();
 				DB::update("update submissions set active_version_id = $history_id, status = '{$result['status']}', result_error = '{$result['error']}', result = '$esc_result', score = null, used_time = null, used_memory = null where id = {$_POST['id']}");
 			} else {
-				DB::update("insert into submissions_history (submission_id, judge_time, judger_name, result, status, result_error, score, used_time, used_memory, status_details) values ({$submissions['id']}, {$submissions['judge_time']}, {$submissions['judger_name']}, '$esc_result', '{$result['status']}', null, {$result['score']}, {$result['time']}, {$result['memory']}, {$submissions['status_details']})");
+				DB::insert("insert into submissions_history (submission_id, judge_time, judger_name, result, status, result_error, score, used_time, used_memory, status_details) values ({$submissions['id']}, '{$submissions['judge_time']}', '{$submissions['judger_name']}', '$esc_result', '{$result['status']}', null, {$result['score']}, {$result['time']}, {$result['memory']}, '{$submissions['status_details']}')");
 				$history_id = DB::insert_id();
 				DB::update("update submissions set active_version_id = $history_id, status = '{$result['status']}', result_error = null, result = '$esc_result', score = {$result['score']}, used_time = {$result['time']}, used_memory = {$result['memory']} where id = {$_POST['id']}");
 			}

--- a/app/controllers/judge/submit.php
+++ b/app/controllers/judge/submit.php
@@ -26,7 +26,7 @@
 			$content['config'] = $content['first_test_config'];
 			unset($content['first_test_config']);
 			$esc_content = DB::escape(json_encode($content));
-			DB::insert("insert into submissions_history (submission_id, judge_time, judger_name, result, status, result_error, score, used_time, used_memory, status_details) values ({$submissions['id']}, '{$submissions['judge_time']}', '{$submissions['judger_name']}', '$esc_result', 'Judged', '{$submissions['result_error']}', {$submissions['score']}, {$submissions['used_time']}, {$submissions['used_memory']}, '{$submissions['status_details']}')");
+			DB::insert("insert into submissions_history (submission_id, judge_time, judger_name, result, status, result_error, score, used_time, used_memory, status_details) values ({$submission['id']}, '{$submission['judge_time']}', '{$submission['judger_name']}', '$esc_result', 'Judged', '{$submission['result_error']}', {$submission['score']}, {$submission['used_time']}, {$submission['used_memory']}, '{$submission['status_details']}')");
 			$history_id = DB::insert_id();
 			DB::update("update submissions set active_version_id = $history_id, status = 'Judged', result = '$esc_result', content = '$esc_content' where id = {$_POST['id']}");
 		} else {
@@ -34,11 +34,11 @@
 			$result['details'] = uojTextEncode($result['details']);
 			$esc_result = DB::escape(json_encode($result, JSON_UNESCAPED_UNICODE));
 			if (isset($result["error"])) {
-				DB::insert("insert into submissions_history (submission_id, judge_time, judger_name, result, status, result_error, score, used_time, used_memory, status_details) values ({$submissions['id']}, '{$submissions['judge_time']}', '{$submissions['judger_name']}', '$esc_result', '{$result['status']}', '{$result['error']}', null, null, null, '{$submissions['status_details']}')");
+				DB::insert("insert into submissions_history (submission_id, judge_time, judger_name, result, status, result_error, score, used_time, used_memory, status_details) values ({$submission['id']}, '{$submission['judge_time']}', '{$submission['judger_name']}', '$esc_result', '{$result['status']}', '{$result['error']}', null, null, null, '{$submission['status_details']}')");
 				$history_id = DB::insert_id();
 				DB::update("update submissions set active_version_id = $history_id, status = '{$result['status']}', result_error = '{$result['error']}', result = '$esc_result', score = null, used_time = null, used_memory = null where id = {$_POST['id']}");
 			} else {
-				DB::insert("insert into submissions_history (submission_id, judge_time, judger_name, result, status, result_error, score, used_time, used_memory, status_details) values ({$submissions['id']}, '{$submissions['judge_time']}', '{$submissions['judger_name']}', '$esc_result', '{$result['status']}', null, {$result['score']}, {$result['time']}, {$result['memory']}, '{$submissions['status_details']}')");
+				DB::insert("insert into submissions_history (submission_id, judge_time, judger_name, result, status, result_error, score, used_time, used_memory, status_details) values ({$submission['id']}, '{$submission['judge_time']}', '{$submission['judger_name']}', '$esc_result', '{$result['status']}', null, {$result['score']}, {$result['time']}, {$result['memory']}, '{$submission['status_details']}')");
 				$history_id = DB::insert_id();
 				DB::update("update submissions set active_version_id = $history_id, status = '{$result['status']}', result_error = null, result = '$esc_result', score = {$result['score']}, used_time = {$result['time']}, used_memory = {$result['memory']} where id = {$_POST['id']}");
 			}

--- a/app/controllers/judge/submit.php
+++ b/app/controllers/judge/submit.php
@@ -7,7 +7,7 @@
 	}
 	
 	function submissionJudged() {
-		$submission = DB::selectFirst("select id, problem_id, submitter, content, judge_time, judger_name, result, status, result_error, score, used_time, used_memory, status_details from submissions where id = {$_POST['id']}");
+		$submission = DB::selectFirst("select id, problem_id, submitter, content, judge_time, judger_name, result, status, result_error, score, used_time, used_memory from submissions where id = {$_POST['id']}");
 		if ($submission == null) {
 			return;
 		}
@@ -26,7 +26,7 @@
 			$content['config'] = $content['first_test_config'];
 			unset($content['first_test_config']);
 			$esc_content = DB::escape(json_encode($content));
-			DB::insert("insert into submissions_history (submission_id, judge_time, judger_name, result, status, result_error, score, used_time, used_memory, status_details) values ({$submission['id']}, '{$submission['judge_time']}', '{$submission['judger_name']}', '$esc_result', 'Judged', '{$submission['result_error']}', {$submission['score']}, {$submission['used_time']}, {$submission['used_memory']}, '{$submission['status_details']}')");
+			DB::insert("insert into submissions_history (submission_id, judge_time, judger_name, result, status, result_error, score, used_time, used_memory) values ({$submission['id']}, '{$submission['judge_time']}', '{$submission['judger_name']}', '$esc_result', 'Judged', '{$submission['result_error']}', {$submission['score']}, {$submission['used_time']}, {$submission['used_memory']})");
 			$history_id = DB::insert_id();
 			DB::update("update submissions set active_version_id = $history_id, status = 'Judged', result = '$esc_result', content = '$esc_content' where id = {$_POST['id']}");
 		} else {
@@ -34,11 +34,11 @@
 			$result['details'] = uojTextEncode($result['details']);
 			$esc_result = DB::escape(json_encode($result, JSON_UNESCAPED_UNICODE));
 			if (isset($result["error"])) {
-				DB::insert("insert into submissions_history (submission_id, judge_time, judger_name, result, status, result_error, score, used_time, used_memory, status_details) values ({$submission['id']}, '{$submission['judge_time']}', '{$submission['judger_name']}', '$esc_result', '{$result['status']}', '{$result['error']}', null, null, null, '{$submission['status_details']}')");
+				DB::insert("insert into submissions_history (submission_id, judge_time, judger_name, result, status, result_error, score, used_time, used_memory) values ({$submission['id']}, '{$submission['judge_time']}', '{$submission['judger_name']}', '$esc_result', '{$result['status']}', '{$result['error']}', null, null, null)");
 				$history_id = DB::insert_id();
 				DB::update("update submissions set active_version_id = $history_id, status = '{$result['status']}', result_error = '{$result['error']}', result = '$esc_result', score = null, used_time = null, used_memory = null where id = {$_POST['id']}");
 			} else {
-				DB::insert("insert into submissions_history (submission_id, judge_time, judger_name, result, status, result_error, score, used_time, used_memory, status_details) values ({$submission['id']}, '{$submission['judge_time']}', '{$submission['judger_name']}', '$esc_result', '{$result['status']}', null, {$result['score']}, {$result['time']}, {$result['memory']}, '{$submission['status_details']}')");
+				DB::insert("insert into submissions_history (submission_id, judge_time, judger_name, result, status, result_error, score, used_time, used_memory) values ({$submission['id']}, '{$submission['judge_time']}', '{$submission['judger_name']}', '$esc_result', '{$result['status']}', null, {$result['score']}, {$result['time']}, {$result['memory']})");
 				$history_id = DB::insert_id();
 				DB::update("update submissions set active_version_id = $history_id, status = '{$result['status']}', result_error = null, result = '$esc_result', score = {$result['score']}, used_time = {$result['time']}, used_memory = {$result['memory']} where id = {$_POST['id']}");
 			}

--- a/app/controllers/judge/submit.php
+++ b/app/controllers/judge/submit.php
@@ -7,7 +7,7 @@
 	}
 	
 	function submissionJudged() {
-		$submission = DB::selectFirst("select submitter, status, content, result, problem_id from submissions where id = {$_POST['id']}");
+		$submission = DB::selectFirst("select id, problem_id, submitter, content, judge_time, judger_name, result, status, result_error, score, used_time, used_memory, status_details from submissions where id = {$_POST['id']}");
 		if ($submission == null) {
 			return;
 		}

--- a/app/controllers/judge/submit.php
+++ b/app/controllers/judge/submit.php
@@ -173,7 +173,7 @@
 			return true;
 		}
 		
-		querySubmissionToJudge('Judged, Waiting', "status = 'Judged, Judging'");
+		querySubmissionToJudge('Judged, Waiting', "judger_name = '" . DB::escape($_POST['judger_name']). "', status = 'Judged, Judging'");
 		if ($submission) {
 			return true;
 		}

--- a/app/uoj-judger-lib.php
+++ b/app/uoj-judger-lib.php
@@ -167,16 +167,16 @@
 	}
 	
 	function rejudgeProblem($problem) {
-		DB::update("update submissions set judge_time = NULL , judger_name = '' , result = '' , score = NULL , status = 'Waiting Rejudge' where problem_id = {$problem['id']}");
+		DB::update("update submissions set active_version_id = NULL , judge_time = NULL , judger_name = '' , result = '' , score = NULL , status = 'Waiting Rejudge' where problem_id = {$problem['id']}");
 	}
 	function rejudgeProblemAC($problem) {
-		DB::update("update submissions set judge_time = NULL , judger_name = '' , result = '' , score = NULL , status = 'Waiting Rejudge' where problem_id = {$problem['id']} and score = 100");
+		DB::update("update submissions set active_version_id = NULL , judge_time = NULL , judger_name = '' , result = '' , score = NULL , status = 'Waiting Rejudge' where problem_id = {$problem['id']} and score = 100");
 	}
 	function rejudgeProblemGe97($problem) {
-		DB::update("update submissions set judge_time = NULL , judger_name = '' , result = '' , score = NULL , status = 'Waiting Rejudge' where problem_id = {$problem['id']} and score >= 97");
+		DB::update("update submissions set active_version_id = NULL , judge_time = NULL , judger_name = '' , result = '' , score = NULL , status = 'Waiting Rejudge' where problem_id = {$problem['id']} and score >= 97");
 	}
 	function rejudgeSubmission($submission) {
-		DB::update("update submissions set judge_time = NULL , judger_name = '' , result = '' , score = NULL , status = 'Waiting Rejudge' where id = {$submission['id']}");
+		DB::update("update submissions set active_version_id = NULL , judge_time = NULL , judger_name = '' , result = '' , score = NULL , status = 'Waiting Rejudge' where id = {$submission['id']}");
 	}
 	function updateBestACSubmissions($username, $problem_id) {
 		$best = DB::selectFirst("select id, used_time, used_memory, tot_size from submissions where submitter = '$username' and problem_id = $problem_id and score = 100 order by used_time, used_memory, tot_size asc limit 1");

--- a/update.md
+++ b/update.md
@@ -139,3 +139,28 @@ alter table submissions add column judger_name varchar(50) not null default '' a
 alter table custom_test_submissions add column judger_name varchar(50) not null default '' after judge_time;
 alter table hacks add column judger_name varchar(50) not null default '' after judge_time;
 ```
+
+### update JUN 13 10:00
+
+```sql
+CREATE TABLE `submissions_history` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `submission_id` int(10) unsigned NOT NULL,
+  `judge_time` datetime DEFAULT NULL,
+  `judger_name` varchar(50) NOT NULL DEFAULT '',
+  `result` mediumblob NOT NULL,
+  `status` varchar(20) NOT NULL,
+  `result_error` varchar(20) DEFAULT NULL,
+  `score` int(11) DEFAULT NULL,
+  `used_time` int(11) NOT NULL DEFAULT '0',
+  `used_memory` int(11) NOT NULL DEFAULT '0',
+  `status_details` varchar(100) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `submission` (`submission_id`,`id`)
+) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+
+alter table submissions add column contest_final_version_id int(10) unsigned default NULL after contest_id;
+alter table submissions add column active_version_id int(10) unsigned default NULL after contest_id;
+insert into submissions_history (submission_id, judge_time, judger_name, result, status, result_error, score, used_time, used_memory, status_details) select id, judge_time, judger_name, result, status, result_error, score, used_time, used_memory, status_details from submissions where status="Judged" order by judge_time asc;
+update submissions inner join submissions_history on submissions.id = submissions_history.submission_id set submissions.active_version_id = submissions_history.id;
+```


### PR DESCRIPTION
支持在数据库中记录评测历史，暂不支持在前端中显示。

将 SOJ 版本号更新至 `7.0-beta.1`。

赛时测样例的提交模拟终测时会改变记录的评测机为模拟终测时的评测机。