### PR TITLE
Support showing submissions_history

### DIFF
--- a/app/.default-config.php
+++ b/app/.default-config.php
@@ -3,7 +3,7 @@ return [
 	'profile' => [
 		'oj-name'  => 'Universal Online Judge',
 		'oj-name-short' => 'UOJ',
-		'oj-version' => '7.0-beta.1',
+		'oj-version' => '7.0-beta.2',
 		'administrator' => 'root',
 		'admin-email' => 'root@uoj',
 		'qq-group' => '1145141919810',

--- a/app/controllers/submission.php
+++ b/app/controllers/submission.php
@@ -14,10 +14,12 @@
 		if (!validateUInt($_GET['judgement_id']) || !($judgement = queryJudgement($_GET['judgement_id'])) || !($judgement['submission_id'] == $submission['id'])) {
 			become404Page();
 		}
+		$submission_judgement = array_merge($submission, $judgement);
 		$judger_name = $judgement['judger_name'];
 		$submission_result = json_decode($judgement['result'], true);
 	} else {
 		$judgement = null;
+		$submission_judgement = $submission;
 		$judger_name = $submission['judger_name'];
 		$submission_result = json_decode($submission['result'], true);
 	}
@@ -136,7 +138,7 @@
 	$REQUIRE_LIB['shjs'] = '';
 ?>
 <?php echoUOJPageHeader(UOJLocale::get('problems::submission').' #'.$submission['id']) ?>
-<?php echoSubmissionsListOnlyOne($submission, array(), Auth::user()) ?>
+<?php echoSubmissionsListOnlyOne($submission_judgement, array(), Auth::user()) ?>
 
 <?php if ($should_show_content) { ?>
 	<?php echoSubmissionContent($submission, getProblemSubmissionRequirement($problem)) ?>

--- a/app/controllers/submission.php
+++ b/app/controllers/submission.php
@@ -10,7 +10,7 @@
 		become404Page();
 	}
 
-	if (isset($_GET['judgement_id']) {
+	if (isset($_GET['judgement_id'])) {
 		if (!validateUInt($_GET['judgement_id']) || !($judgement = queryJudgement($_GET['judgement_id'])) || !($judgement['submission_id'] == $submission['id'])) {
 			become404Page();
 		}

--- a/app/controllers/submission.php
+++ b/app/controllers/submission.php
@@ -17,6 +17,8 @@
 			become404Page();
 		}
 		$submission_judgement = array_merge($submission, $judgement);
+		$submission_judgement['judgement_id'] = $judgement['id'];
+		$submission_judgement['id'] = $submission['id'];
 		$judger_name = $judgement['judger_name'];
 		$submission_result = json_decode($judgement['result'], true);
 	} else {
@@ -143,6 +145,17 @@
 <?php echoUOJPageHeader(UOJLocale::get('problems::submission').' #'.$submission['id']) ?>
 <?php echoSubmissionsListOnlyOne($submission_judgement, array(), Auth::user()) ?>
 
+<?php if ($should_show_timeline) { ?>
+	<div class="panel panel-info">
+		<div class="panel-heading">
+			<h4 class="panel-title"><?= UOJLocale::get('submission history') ?></h4>
+		</div>
+		<div class="panel-body">
+			<?php echoSubmissionTimeline($submission, $time_now) ?>
+		</div>
+	</div>
+<?php } ?>
+
 <?php if ($should_show_content) { ?>
 	<?php echoSubmissionContent($submission, getProblemSubmissionRequirement($problem)) ?>
 	<?php if ($hackable) { ?>
@@ -160,17 +173,6 @@
 			});
 		</script>
 	<?php } ?>
-<?php } ?>
-
-<?php if ($should_show_timeline) { ?>
-	<div class="panel panel-info">
-		<div class="panel-heading">
-			<h4 class="panel-title"><?= UOJLocale::get('submission history') ?></h4>
-		</div>
-		<div class="panel-body">
-			<?php echoSubmissionTimeline($submission, $time_now) ?>
-		</div>
-	</div>
 <?php } ?>
 
 <?php if ($should_show_judger_info) { ?>

--- a/app/controllers/submission.php
+++ b/app/controllers/submission.php
@@ -10,6 +10,8 @@
 		become404Page();
 	}
 
+	$time_now = DB::query_time_now();
+
 	if (isset($_GET['judgement_id'])) {
 		if (!validateUInt($_GET['judgement_id']) || !($judgement = queryJudgement($_GET['judgement_id'])) || !($judgement['submission_id'] == $submission['id'])) {
 			become404Page();
@@ -108,7 +110,8 @@
 		$delete_form->succ_href = '/submissions';
 		$delete_form->runAtServer();
 	}
-	
+
+	$should_show_timeline = true;
 	$should_show_judger_info = hasViewJudgerInfoPermission(Auth::user());
 	$should_show_content = hasViewPermission($problem_extra_config['view_content_type'], Auth::user(), $problem, $submission);
 	$should_show_all_details = hasViewPermission($problem_extra_config['view_all_details_type'], Auth::user(), $problem, $submission);
@@ -157,6 +160,17 @@
 			});
 		</script>
 	<?php } ?>
+<?php } ?>
+
+<?php if ($should_show_timeline) { ?>
+	<div class="panel panel-info">
+		<div class="panel-heading">
+			<h4 class="panel-title"><?= UOJLocale::get('submission history') ?></h4>
+		</div>
+		<div class="panel-body">
+			<?php echoSubmissionTimeline($submission, $time_now) ?>
+		</div>
+	</div>
 <?php } ?>
 
 <?php if ($should_show_judger_info) { ?>

--- a/app/locale/basic/en.php
+++ b/app/locale/basic/en.php
@@ -36,6 +36,7 @@ return [
 	'submit' => 'Submit',
 	'browse' => 'Browse',
 	'score range' => 'Score range',
+	'submission history' => 'Submission History',
 	'judger info' => 'Judger Info',
 	'details' => 'Details',
 	'hours' => function($h) {

--- a/app/locale/basic/zh-cn.php
+++ b/app/locale/basic/zh-cn.php
@@ -36,6 +36,7 @@ return [
 	'submit' => '提交',
 	'browse' => '浏览',
 	'score range' => '分数范围',
+	'submission history' => '测评历史',
 	'judger info' => '评测机信息',
 	'details' => '详细',
 	'hours' => function($h) {

--- a/app/models/DB.php
+++ b/app/models/DB.php
@@ -66,6 +66,13 @@ class DB {
 		global $uojMySQL;
 		return DB::query("select 1 from $name limit 1") !== false;
 	}
+
+	public static function query_time_now() {
+		global $uojMySQL;
+		$time_now = DB::select("select now()");
+        	$time_now = DB::fetch($time_now);
+		return $time_now['now()'];
+	}
 	
 	public static function num_rows() {
 		global $uojMySQL;

--- a/app/uoj-html-lib.php
+++ b/app/uoj-html-lib.php
@@ -517,16 +517,18 @@ function echoSubmissionMessages($messages) {
 				$main_message .= '<ul class="list-group-item-text list-inline">';
 				$main_message .= '<li>';
 				$main_message .= '<strong>测评结果：</strong>';
-				$main_message .= isset($mes['result_error'])?$mes['result_error']:$mes['score'];
+				$main_message .= isset($mes['result_error'])?"<div class=\"small\">{$mes['result_error']}</div>":"<div class=\"uoj-score\">{$mes['score']}</div>";
 				$main_message .= '</li>';
-				$main_message .= '<li>';
-				$main_message .= '<strong>用时：</strong>';
-				$main_message .= $used_time;
-				$main_message .= '</li>';
-				$main_message .= '<li>';
-				$main_message .= '<strong>内存：</strong>';
-				$main_message .= $used_memory;
-				$main_message .= '</li>';
+				if (!isset($mes['result_error'])) {
+					$main_message .= '<li>';
+					$main_message .= '<strong>用时：</strong>';
+					$main_message .= $mes['used_time'] . 'ms';
+					$main_message .= '</li>';
+					$main_message .= '<li>';
+					$main_message .= '<strong>内存：</strong>';
+					$main_message .= $mes['used_memory'] . 'KiB';
+					$main_message .= '</li>';
+				}
 				$main_message .= '</ul>';
 				$extra = '<a href="'."/submission/{$mes['submission_id']}?judgement_id={$mes['judgement_id']}".'"><span class="glyphicon glyphicon-info-sign"></span> 查看</a>';
 				break;

--- a/app/uoj-html-lib.php
+++ b/app/uoj-html-lib.php
@@ -517,7 +517,7 @@ function echoSubmissionMessages($messages) {
 				$main_message .= '<ul class="list-group-item-text list-inline">';
 				$main_message .= '<li>';
 				$main_message .= '<strong>测评结果：</strong>';
-				$main_message .= isset($mes['result_error'])?"<div class=\"small\">{$mes['result_error']}</div>":"<div class=\"uoj-score\">{$mes['score']}</div>";
+				$main_message .= isset($mes['result_error'])?"<span class=\"small\">{$mes['result_error']}</span>":"<span class=\"uoj-score\">{$mes['score']}</span>";
 				$main_message .= '</li>';
 				if (!isset($mes['result_error'])) {
 					$main_message .= '<li>';

--- a/app/uoj-query-lib.php
+++ b/app/uoj-query-lib.php
@@ -101,6 +101,10 @@ function querySubmission($id) {
 	return DB::selectFirst("select * from submissions where id = $id", MYSQLI_ASSOC);
 }
 
+function queryJudgement($id) {
+	return DB::selectFirst("select * from submissions_history where id = $id", MYSQLI_ASSOC);
+}
+
 function queryHack($id) {
 	return DB::selectFirst("select * from hacks where id = $id", MYSQLI_ASSOC);
 }

--- a/css/soj-theme.css
+++ b/css/soj-theme.css
@@ -196,6 +196,28 @@ pre {
 	vertical-align: middle;
 }
 
+@media (min-width: 768px) {
+	.vcenter-sm {
+		display: inline-block;
+		vertical-align: middle;
+		float: none;
+	}
+}
+@media (min-width: 992px) {
+	.vcenter-md {
+		display: inline-block;
+		vertical-align: middle;
+		float: none;
+	}
+}
+@media (min-width: 1200px) {
+	.vcenter-lg {
+		display: inline-block;
+		vertical-align: middle;
+		float: none;
+	}
+}
+
 .top-buffer-no {
 	margin-top: 0px;
 }

--- a/css/soj-theme.css
+++ b/css/soj-theme.css
@@ -415,3 +415,37 @@ a.uoj-index-ranklist:visited {
 a.uoj-index-ranklist:hover {
 	color: #428bca;
 }
+
+.list-group.timeline {
+	margin: auto;
+}
+
+@media(min-width: 768px) {
+	.list-group.timeline {
+		display: block;
+		max-width: 90%;
+		position: relative;
+	}
+	.list-group.timeline:before {
+		content: ' ';
+		background: #d4d9df;
+		display: inline-block;
+		position: absolute;
+		left: -17.5px;
+		width: 2px;
+		height: 100%;
+		z-index: 400;
+	}
+	.list-group.timeline > .list-group-item:before {
+		content: ' ';
+		background: white;
+		display: inline-block;
+		position: absolute;
+		border-radius: 50%;
+		border: 3px solid #22c0e8;
+		left: -25px;
+		width: 15px;
+		height: 15px;
+		z-index: 500;
+	}
+}


### PR DESCRIPTION
支持通过 `/submission/{id}?judgement_id={judgement_id}` 查看历史评测结果。

在 `/submission/{id}` 和 `/submission/{id}?judgement_id={judgement_id}` 页面中添加了测评历史的时间轴，将登录需求移至检查编号合法之前。

将 SOJ 版本号更新至 `7.0-beta.2`。

添加了函数 `queryJudgement` `DB::query_time_now` `echoSubmissionMessages` `echoSubmissionTimeline`。