### PR TITLE
Add audit_log.

### DIFF
--- a/app/.default-config.php
+++ b/app/.default-config.php
@@ -3,7 +3,7 @@ return [
 	'profile' => [
 		'oj-name'  => 'Universal Online Judge',
 		'oj-name-short' => 'UOJ',
-		'oj-version' => '7.0-beta.2',
+		'oj-version' => '7.0-beta.3',
 		'administrator' => 'root',
 		'admin-email' => 'root@uoj',
 		'qq-group' => '1145141919810',

--- a/app/controllers/judge/submit.php
+++ b/app/controllers/judge/submit.php
@@ -88,7 +88,7 @@
 			if ($result['score']) {
 				list($problem_id) = DB::selectFirst("select problem_id from hacks where id = {$_POST['id']}", MYSQLI_NUM);
 				if (validateUploadedFile('hack_input') && validateUploadedFile('std_output')) {
-					dataAddExtraTest(queryProblemBrief($problem_id), $_FILES["hack_input"]["tmp_name"], $_FILES["std_output"]["tmp_name"], array('reason' => 'successful hack', 'auto' => true));
+					dataAddExtraTest(queryProblemBrief($problem_id), $_FILES["hack_input"]["tmp_name"], $_FILES["std_output"]["tmp_name"], array('reason' => 'successful hack', 'data_source' => array('source' => 'hack', 'hack_id' => $_POST['id']), 'auto' => true));
 				} else {
 					error_log("hack successfully but received no data. id: {$_POST['id']}");
 				}

--- a/app/controllers/judge/submit.php
+++ b/app/controllers/judge/submit.php
@@ -88,7 +88,7 @@
 			if ($result['score']) {
 				list($problem_id) = DB::selectFirst("select problem_id from hacks where id = {$_POST['id']}", MYSQLI_NUM);
 				if (validateUploadedFile('hack_input') && validateUploadedFile('std_output')) {
-					dataAddExtraTest(queryProblemBrief($problem_id), $_FILES["hack_input"]["tmp_name"], $_FILES["std_output"]["tmp_name"]);
+					dataAddExtraTest(queryProblemBrief($problem_id), $_FILES["hack_input"]["tmp_name"], $_FILES["std_output"]["tmp_name"], array('reason' => 'successful hack', 'auto' => true));
 				} else {
 					error_log("hack successfully but received no data. id: {$_POST['id']}");
 				}

--- a/app/controllers/problem_data_manage.php
+++ b/app/controllers/problem_data_manage.php
@@ -57,6 +57,7 @@
 				move_uploaded_file($_FILES['problem_data_file']['tmp_name'], $up_filename . '.zip');
 				$zip = new ZipArchive();
 				if ($zip->open($up_filename . '.zip') === true) {
+					insertAuditLog('problems','data uploading',$id,'','');
 					$data_upload_dir = "/var/uoj_data/upload/{$problem['id']}";
 					is_dir($data_upload_dir) or mkdir($data_upload_dir, 0777, true);
 					$zip->extractTo($up_filename);

--- a/app/controllers/problem_data_manage.php
+++ b/app/controllers/problem_data_manage.php
@@ -57,7 +57,7 @@
 				move_uploaded_file($_FILES['problem_data_file']['tmp_name'], $up_filename . '.zip');
 				$zip = new ZipArchive();
 				if ($zip->open($up_filename . '.zip') === true) {
-					insertAuditLog('problems','data uploading',$id,'','');
+					insertAuditLog('problems','data uploading',$problem['id'],'','');
 					$data_upload_dir = "/var/uoj_data/upload/{$problem['id']}";
 					is_dir($data_upload_dir) or mkdir($data_upload_dir, 0777, true);
 					$zip->extractTo($up_filename);
@@ -462,13 +462,13 @@ EOD
 		$hackable_form->handle = function() {
 			global $problem;
 			$problem['hackable'] = !$problem['hackable'];
-			insertAuditLog('problems','flip hackable-status',$id,'',json_encode(
+			insertAuditLog('problems','flip hackable-status',$problem['id'],'',json_encode(
 					array('hackable-status' => ($problem['hackable'] ? 1 : 0))
 				));
 			set_time_limit(600);
 			$ret = dataSyncProblemData($problem, (bool)isSuperUser(Auth::user()), array('reason' => 'flip hackable-status', 'auto' => true));
 			if ($ret) {
-				insertAuditLog('problems','flip hackable-status failed',$id,'',json_encode(
+				insertAuditLog('problems','flip hackable-status failed',$problem['id'],'',json_encode(
 					array('final hackable-status' => ($problem['hackable'] ? 0 : 1), 'exception_message' => $ret)
 				), array('auto' => true));
 				becomeMsgPage('<div>' . $ret . '</div><a href="/problem/' . $problem['id'] . '/manage/data">返回</a>');
@@ -589,7 +589,7 @@ EOD
 		$config['view_content_type'] = $_POST['view_content_type'];
 		$config['view_all_details_type'] = $_POST['view_all_details_type'];
 		$config['view_details_type'] = $_POST['view_details_type'];
-		insertAuditLog('problems','update extra_config',$id,'',json_encode(
+		insertAuditLog('problems','update extra_config',$problem['id'],'',json_encode(
 					array('config' => $config)
 				));
 		$esc_config = DB::escape(json_encode($config));
@@ -655,7 +655,7 @@ EOD
 		global $problem;
 		$problem['data_locked'] = !$problem['data_locked'];
 		$hackable = $problem['data_locked'] ? 1 : 0;
-		insertAuditLog('problems','flip data-locked-status',$id,'',json_encode(
+		insertAuditLog('problems','flip data-locked-status',$problem['id'],'',json_encode(
 					array('data-locked-status' => $hackable)
 				));
 		DB::update("update problems set data_locked = $hackable where id = {$problem['id']}");

--- a/app/controllers/problem_data_manage.php
+++ b/app/controllers/problem_data_manage.php
@@ -461,9 +461,15 @@ EOD
 		$hackable_form->handle = function() {
 			global $problem;
 			$problem['hackable'] = !$problem['hackable'];
+			insertAuditLog('problems','flip hackable-status',$id,'',json_encode(
+					array('hackable-status' => ($problem['hackable'] ? 1 : 0))
+				));
 			set_time_limit(600);
-			$ret = dataSyncProblemData($problem, (bool)isSuperUser(Auth::user()));
+			$ret = dataSyncProblemData($problem, (bool)isSuperUser(Auth::user()), array('reason' => 'flip hackable-status', 'auto' => true));
 			if ($ret) {
+				insertAuditLog('problems','flip hackable-status failed',$id,'',json_encode(
+					array('final hackable-status' => ($problem['hackable'] ? 0 : 1), 'exception_message' => $ret)
+				), array('auto' => true));
 				becomeMsgPage('<div>' . $ret . '</div><a href="/problem/' . $problem['id'] . '/manage/data">返回</a>');
 			}
 			
@@ -582,6 +588,9 @@ EOD
 		$config['view_content_type'] = $_POST['view_content_type'];
 		$config['view_all_details_type'] = $_POST['view_all_details_type'];
 		$config['view_details_type'] = $_POST['view_details_type'];
+		insertAuditLog('problems','update extra_config',$id,'',json_encode(
+					array('config' => $config)
+				));
 		$esc_config = DB::escape(json_encode($config));
 		DB::update("update problems set extra_config = '$esc_config' where id = '{$problem['id']}'");
 	};
@@ -645,6 +654,9 @@ EOD
 		global $problem;
 		$problem['data_locked'] = !$problem['data_locked'];
 		$hackable = $problem['data_locked'] ? 1 : 0;
+		insertAuditLog('problems','flip data-locked-status',$id,'',json_encode(
+					array('data-locked-status' => $hackable)
+				));
 		DB::update("update problems set data_locked = $hackable where id = {$problem['id']}");
 	};
 	$problem_lock_form->submit_button_config['class_str'] = 

--- a/app/uoj-data-lib.php
+++ b/app/uoj-data-lib.php
@@ -372,7 +372,7 @@
 		if ($problem_conf == -1 || $problem_conf == -2) {
 			return $problem_conf;
 		}
-		insertAuditLog('problems', 'add extra_test', $id, isset($log_config['reason'])?$log_config['reason']:'', '', $log_config);
+		insertAuditLog('problems', 'add extra_test', $id, isset($log_config['reason'])?$log_config['reason']:'', isset($log_config['source'])?json_encode($log_config['source']):'', $log_config);
 		
 		$problem_conf['n_ex_tests'] = getUOJConfVal($problem_conf, 'n_ex_tests', 0) + 1;
 		

--- a/app/uoj-data-lib.php
+++ b/app/uoj-data-lib.php
@@ -375,7 +375,7 @@
 		move_uploaded_file($output_file_name, "$cur_dir/$new_output_name");
 
 		if (dataSyncProblemData($problem, true) === '') {
-			rejudgeProblemAC($problem);
+			rejudgeProblemAC($problem, array('auto' => true));
 		} else {
 			error_log('hack successfully but sync failed.');
 		}

--- a/app/uoj-data-lib.php
+++ b/app/uoj-data-lib.php
@@ -20,13 +20,14 @@
 		}
 	}
 
-	function dataClearProblemData($problem) {
+	function dataClearProblemData($problem, $log_config=array()) {
 		$id = $problem['id'];
-		clearJudgerData($id);
 		if (!validateUInt($id)) {
 			error_log("dataClearProblemData: hacker detected");
 			return "invalid problem id";
 		}
+		insertAuditLog('problems', 'clear data', $id, isset($log_config['reason'])?$log_config['reason']:'', '', $log_config);
+		clearJudgerData($id);
 
 		exec("rm /var/uoj_data/upload/$id -r");
 		exec("rm /var/uoj_data/$id -r");
@@ -382,7 +383,7 @@
 		move_uploaded_file($input_file_name, "$cur_dir/$new_input_name");
 		move_uploaded_file($output_file_name, "$cur_dir/$new_output_name");
 
-		if (dataSyncProblemData($problem, true) === '') {
+		if (dataSyncProblemData($problem, true, array('reason' => 'add extra_test', 'auto' => true)) === '') {
 			rejudgeProblemAC($problem, array('auto' => true));
 		} else {
 			insertAuditLog('problems', 'add extra_test failed', $id, '', '', array('auto' => true));

--- a/app/uoj-data-lib.php
+++ b/app/uoj-data-lib.php
@@ -356,7 +356,7 @@
 		return (new SyncProblemDataHandler($problem, $permission_level, array('no_compile' => '')))->handle();
 	}
 
-	function dataAddExtraTest($problem, $input_file_name, $output_file_name) {
+	function dataAddExtraTest($problem, $input_file_name, $output_file_name, $log_config=array()) {
 		$id = $problem['id'];
 		
 		$cur_dir = "/var/uoj_data/upload/$id";
@@ -374,7 +374,7 @@
 		move_uploaded_file($input_file_name, "$cur_dir/$new_input_name");
 		move_uploaded_file($output_file_name, "$cur_dir/$new_output_name");
 
-		insertAuditLog('problems', 'add extra_test', $id, 'successful hack', '', array('auto' => true));
+		insertAuditLog('problems', 'add extra_test', $id, isset($log_config['reason'])?$log_config['reason']:'', '', $log_config);
 		if (dataSyncProblemData($problem, true) === '') {
 			rejudgeProblemAC($problem, array('auto' => true));
 		} else {

--- a/app/uoj-data-lib.php
+++ b/app/uoj-data-lib.php
@@ -372,7 +372,7 @@
 		if ($problem_conf == -1 || $problem_conf == -2) {
 			return $problem_conf;
 		}
-		insertAuditLog('problems', 'add extra_test', $id, isset($log_config['reason'])?$log_config['reason']:'', isset($log_config['source'])?json_encode($log_config['source']):'', $log_config);
+		insertAuditLog('problems', 'add extra_test', $id, isset($log_config['reason'])?$log_config['reason']:'', isset($log_config['data_source'])?json_encode($log_config['data_source']):'', $log_config);
 		
 		$problem_conf['n_ex_tests'] = getUOJConfVal($problem_conf, 'n_ex_tests', 0) + 1;
 		

--- a/app/uoj-data-lib.php
+++ b/app/uoj-data-lib.php
@@ -374,9 +374,11 @@
 		move_uploaded_file($input_file_name, "$cur_dir/$new_input_name");
 		move_uploaded_file($output_file_name, "$cur_dir/$new_output_name");
 
+		insertAuditLog('problems', 'add extra_test', $id, 'successful hack', '', array('auto' => true));
 		if (dataSyncProblemData($problem, true) === '') {
 			rejudgeProblemAC($problem, array('auto' => true));
 		} else {
+			insertAuditLog('problems', 'add extra_test failed', $id, '', '', array('auto' => true));
 			error_log('hack successfully but sync failed.');
 		}
 	}

--- a/app/uoj-judger-lib.php
+++ b/app/uoj-judger-lib.php
@@ -167,19 +167,19 @@
 	}
 	
 	function rejudgeProblem($problem, $log_config=array()) {
-		insertAuditLog('problems','rejudge',$problem['id'],isset($log_config['reason'])?$log_config['reason']:'',isset($log_config['details'])?$log_config['details']:'',$log_config);
+		insertAuditLog('problems','rejudge',$problem['id'],isset($log_config['reason'])?$log_config['reason']:'','',$log_config);
 		DB::update("update submissions set active_version_id = NULL , judge_time = NULL , judger_name = '' , result = '' , score = NULL , status = 'Waiting Rejudge' where problem_id = {$problem['id']}");
 	}
 	function rejudgeProblemAC($problem, $log_config=array()) {
-		insertAuditLog('problems','rejudge AC',$problem['id'],isset($log_config['reason'])?$log_config['reason']:'',isset($log_config['details'])?$log_config['details']:'',$log_config);
+		insertAuditLog('problems','rejudge AC',$problem['id'],isset($log_config['reason'])?$log_config['reason']:'','',$log_config);
 		DB::update("update submissions set active_version_id = NULL , judge_time = NULL , judger_name = '' , result = '' , score = NULL , status = 'Waiting Rejudge' where problem_id = {$problem['id']} and score = 100");
 	}
 	function rejudgeProblemGe97($problem, $log_config=array()) {
-		insertAuditLog('problems','rejudge Ge97',$problem['id'],isset($log_config['reason'])?$log_config['reason']:'',isset($log_config['details'])?$log_config['details']:'',$log_config);
+		insertAuditLog('problems','rejudge Ge97',$problem['id'],isset($log_config['reason'])?$log_config['reason']:'','',$log_config);
 		DB::update("update submissions set active_version_id = NULL , judge_time = NULL , judger_name = '' , result = '' , score = NULL , status = 'Waiting Rejudge' where problem_id = {$problem['id']} and score >= 97");
 	}
 	function rejudgeSubmission($submission, $log_config=array()) {
-		insertAuditLog('submissions','rejudge',$submission['id'],isset($log_config['reason'])?$log_config['reason']:'',isset($log_config['details'])?$log_config['details']:'',$log_config);
+		insertAuditLog('submissions','rejudge',$submission['id'],isset($log_config['reason'])?$log_config['reason']:'','',$log_config);
 		DB::update("update submissions set active_version_id = NULL , judge_time = NULL , judger_name = '' , result = '' , score = NULL , status = 'Waiting Rejudge' where id = {$submission['id']}");
 	}
 	function updateBestACSubmissions($username, $problem_id) {

--- a/app/uoj-judger-lib.php
+++ b/app/uoj-judger-lib.php
@@ -166,16 +166,20 @@
 		return 'ex_' . getUOJConfVal($problem_conf, 'output_pre', 'output') . $num . '.' . getUOJConfVal($problem_conf, 'output_suf', 'txt');
 	}
 	
-	function rejudgeProblem($problem) {
+	function rejudgeProblem($problem, $log_config=array()) {
+		insertAuditLog('problems','rejudge',$problem['id'],isset($log_config['reason'])?$log_config['reason']:'',isset($log_config['details'])?$log_config['details']:'',$log_config);
 		DB::update("update submissions set active_version_id = NULL , judge_time = NULL , judger_name = '' , result = '' , score = NULL , status = 'Waiting Rejudge' where problem_id = {$problem['id']}");
 	}
-	function rejudgeProblemAC($problem) {
+	function rejudgeProblemAC($problem, $log_config=array()) {
+		insertAuditLog('problems','rejudge AC',$problem['id'],isset($log_config['reason'])?$log_config['reason']:'',isset($log_config['details'])?$log_config['details']:'',$log_config);
 		DB::update("update submissions set active_version_id = NULL , judge_time = NULL , judger_name = '' , result = '' , score = NULL , status = 'Waiting Rejudge' where problem_id = {$problem['id']} and score = 100");
 	}
-	function rejudgeProblemGe97($problem) {
+	function rejudgeProblemGe97($problem, $log_config=array()) {
+		insertAuditLog('problems','rejudge Ge97',$problem['id'],isset($log_config['reason'])?$log_config['reason']:'',isset($log_config['details'])?$log_config['details']:'',$log_config);
 		DB::update("update submissions set active_version_id = NULL , judge_time = NULL , judger_name = '' , result = '' , score = NULL , status = 'Waiting Rejudge' where problem_id = {$problem['id']} and score >= 97");
 	}
-	function rejudgeSubmission($submission) {
+	function rejudgeSubmission($submission, $log_config=array()) {
+		insertAuditLog('submissions','rejudge',$submission['id'],isset($log_config['reason'])?$log_config['reason']:'',isset($log_config['details'])?$log_config['details']:'',$log_config);
 		DB::update("update submissions set active_version_id = NULL , judge_time = NULL , judger_name = '' , result = '' , score = NULL , status = 'Waiting Rejudge' where id = {$submission['id']}");
 	}
 	function updateBestACSubmissions($username, $problem_id) {

--- a/app/uoj-utility-lib.php
+++ b/app/uoj-utility-lib.php
@@ -207,6 +207,8 @@ function sendSystemMsgToUsers($users, $title, $content) {
 }
 
 function insertAuditLog($scope, $type, $id_in_scope, $reason, $details, $config=array()) {
+	$scope = DB::escape($scope);
+	$type = DB::escape($type);
 	$reason = DB::escape($reason);
 	$details = DB::escape($details);
 	if (isset($config['auto'])) {

--- a/app/uoj-utility-lib.php
+++ b/app/uoj-utility-lib.php
@@ -221,7 +221,7 @@ function insertAuditLog($scope, $type, $id_in_scope, $reason, $details, $config=
 		if (!isset($config['actor'])) {
 			$config['actor'] = Auth::id();
 			$config['actor_remote_addr'] = $_SERVER['REMOTE_ADDR'];
-			$config['actor_http_x_forwarded_for'] = $_SERVER['HTTP_X_FORWARDED_HOST'];
+			$config['actor_http_x_forwarded_for'] = $_SERVER['HTTP_X_FORWARDED_FOR'];
 		}
 	}
 	DB::insert("insert into audit_log (scope, type, id_in_scope, time, actor, actor_remote_addr, actor_http_x_forwarded_for, reason, details) values ('$scope', '$type', $id_in_scope, now(), '{$config['actor']}', '{$config['actor_remote_addr']}', '{$config['actor_http_x_forwarded_for']}', '$reason', '$details')");

--- a/app/uoj-utility-lib.php
+++ b/app/uoj-utility-lib.php
@@ -205,3 +205,22 @@ function sendSystemMsgToUsers($users, $title, $content) {
 	}
 	DB::insert("insert into user_system_msg (receiver, title, content, send_time) values " . $values);
 }
+
+function insertAuditLog($scope, $type, $id_in_scope, $reason, $details, $config=array()) {
+	$reason = DB::escape($reason);
+	$details = DB::escape($details);
+	if (isset($config['auto'])) {
+		$type .= ', auto';
+		$config['actor'] = '';
+		$config['actor_remote_addr'] = '';
+		$config['actor_http_x_forwarded_for'] = '';
+	}
+	else {
+		if (!isset($config['actor'])) {
+			$config['actor'] = Auth::id();
+			$config['actor_remote_addr'] = $_SERVER['REMOTE_ADDR'];
+			$config['actor_http_x_forwarded_for'] = $_SERVER['HTTP_X_FORWARDED_HOST'];
+		}
+	}
+	DB::insert("insert into audit_log (scope, type, id_in_scope, time, actor, actor_remote_addr, actor_http_x_forwarded_for, reason, details) values ('$scope', '$type', $id_in_scope, now(), '{$config['actor']}', '{$config['actor_remote_addr']}', '{$config['actor_http_x_forwarded_for']}', '$reason', '$details')");
+}

--- a/update.md
+++ b/update.md
@@ -164,3 +164,33 @@ alter table submissions add column active_version_id int(10) unsigned default NU
 insert into submissions_history (submission_id, judge_time, judger_name, result, status, result_error, score, used_time, used_memory, status_details) select id, judge_time, judger_name, result, status, result_error, score, used_time, used_memory, status_details from submissions where status="Judged" order by judge_time asc;
 update submissions inner join submissions_history on submissions.id = submissions_history.submission_id set submissions.active_version_id = submissions_history.id;
 ```
+
+### update JUN 24 20:45
+
+```sql
+CREATE TABLE `important_system_updates` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `scope` varchar(20) NOT NULL,
+  `title` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
+  `blog_id` int(10) unsigned NOT NULL,
+  `update_time` datetime NOT NULL,
+  `updater` varchar(20) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `scope` (`scope`)
+) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+
+CREATE TABLE `audit_log` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `scope` varchar(20) NOT NULL,
+  `type` varchar(50) NOT NULL,
+  `id_in_scope` int(10) unsigned NOT NULL,
+  `time` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `actor` varchar(20) NOT NULL,
+  `actor_remote_addr` varchar(50) NOT NULL,
+  `actor_http_x_forwarded_for` varchar(50) NOT NULL,
+  `reason` varchar(100) NOT NULL,
+  `details` text NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `id_in_scope` (`scope`,`id_in_scope`)
+) ENGINE=MyISAM AUTO_INCREMENT=1 DEFAULT CHARSET=utf8;
+```


### PR DESCRIPTION
新增了数据表 `audit_log` 对用户和系统的一些行为进行了记录。新增了数据表 `important_system_updates` 待使用。可以使用 `insertAuditLog` 插入一条日志。

对重测、`hack` 后添加 `extra_test` 进行了记录。

对 `上传数据`（`data uploading`）、`完全/快速同步数据`（`data preparing`）、`禁止/允许使用 hack`、`修改提交记录可视权限`、`清空题目数据`、`锁定题目数据` 进行了记录。