### PR TITLE
Show more information in problem pages

### DIFF
--- a/app/controllers/add_group.php
+++ b/app/controllers/add_group.php
@@ -60,7 +60,7 @@
 ?>
 <?php echoUOJPageHeader(UOJLocale::get('new group')) ?>
 
-<h2 class="page-header"><?= UOJLocale::get('new group') ?></h2>
+<h2><?= UOJLocale::get('new group') ?></h2>
 
 <?php $group_form->printHTML(); ?>
 

--- a/app/controllers/change_user_info.php
+++ b/app/controllers/change_user_info.php
@@ -61,7 +61,7 @@
 	$REQUIRE_LIB['md5'] = '';
 ?>
 <?php echoUOJPageHeader(UOJLocale::get('modify my profile')) ?>
-<h2 class="page-header"><?= UOJLocale::get('modify my profile') ?></h2>
+<h2><?= UOJLocale::get('modify my profile') ?></h2>
 <form id="form-update" class="form-horizontal">
 	<h4><?= UOJLocale::get('please enter your password for authorization') ?></h4>
 	<div id="div-old_password" class="form-group">

--- a/app/controllers/contest_registration.php
+++ b/app/controllers/contest_registration.php
@@ -69,7 +69,7 @@
 	}
 ?>
 <?php echoUOJPageHeader(HTML::stripTags($contest['name']) . ' - 报名') ?>
-<h2 class="page-header">比赛规则</h2>
+<h2>比赛规则</h2>
 <ul>
 <?php if ($contest['extra_config']['standings_version'] === 5) { ?>
 	<li>比赛报名后不算正式参赛，报名后进了比赛页面也不算参赛，<strong>看了题目才算正式参赛</strong>。如果未正式参赛则不算 rating。</li>

--- a/app/controllers/faq.php
+++ b/app/controllers/faq.php
@@ -1,7 +1,7 @@
 <?php echoUOJPageHeader(UOJLocale::get('help')) ?>
 <article>
 	<header>
-		<h2 class="page-header"><?= UOJLocale::get('faq') ?></h2>
+		<h2><?= UOJLocale::get('faq') ?></h2>
 	</header>
 	<section>
 		<header>

--- a/app/controllers/file_upload.php
+++ b/app/controllers/file_upload.php
@@ -214,7 +214,7 @@ EOD;
 ?>
 <?php echoUOJPageHeader(UOJLocale::get('file upload')); ?>
 
-<h2 class="page-header"><?= UOJLocale::get('file upload') ?></h2>
+<h2><?= UOJLocale::get('file upload') ?></h2>
 
 <?php $upload_form->printHTML(); ?>
 

--- a/app/controllers/forgot_pw.php
+++ b/app/controllers/forgot_pw.php
@@ -22,7 +22,7 @@
 		$oj_name = UOJConfig::$data['profile']['oj-name'];
 		$oj_name_short = UOJConfig::$data['profile']['oj-name-short'];
 		$sufs = base64url_encode($user['username'] . '.' . md5($user['username'] . '+' . $password));
-		$url = HTML::url('/reset-password', array('params' => array('p' => $sufs)));
+		$url = HTML::url('/reset-password', array('params' => array('p' => $sufs), 'absolute' => true));
 		error_log($user['username'] . ' : ' . $url);
 		$html = <<<EOD
 <base target="_blank" />
@@ -56,7 +56,7 @@ EOD;
 	$forgot_form->runAtServer();
 ?>
 <?php echoUOJPageHeader(UOJLocale::get('retrieve password')) ?>
-<h2 class="page-header"><?= UOJLocale::get('retrieve password') ?></h2>
+<h2><?= UOJLocale::get('retrieve password') ?></h2>
 <h4><?= UOJLocale::get('enter username to password') ?>:</h4>
 <?php $forgot_form->printHTML(); ?>
 <?php echoUOJPageFooter() ?>

--- a/app/controllers/group_edit.php
+++ b/app/controllers/group_edit.php
@@ -105,7 +105,7 @@
 ?>
 <?php echoUOJPageHeader(UOJLocale::get('edit group')) ?>
 
-<h2 class="page-header"><?= UOJLocale::get('edit group') ?></h2>
+<h2><?= UOJLocale::get('edit group') ?></h2>
 
 <h3><?= UOJLocale::get('basic profile') ?></h3>
 

--- a/app/controllers/login.php
+++ b/app/controllers/login.php
@@ -47,7 +47,7 @@
 	$REQUIRE_LIB['md5'] = '';
 ?>
 <?php echoUOJPageHeader(UOJLocale::get('login')) ?>
-<h2 class="page-header"><?= UOJLocale::get('login') ?></h2>
+<h2><?= UOJLocale::get('login') ?></h2>
 <form id="form-login" class="form-horizontal" method="post">
   <div id="div-username" class="form-group">
     <label for="input-username" class="col-sm-2 control-label"><?= UOJLocale::get('username') ?></label>

--- a/app/controllers/problem_data_manage.php
+++ b/app/controllers/problem_data_manage.php
@@ -698,7 +698,7 @@ EOD
 	$REQUIRE_LIB['dialog'] = '';
 ?>
 <?php echoUOJPageHeader(HTML::stripTags($problem['title']) . ' - 数据 - 题目管理') ?>
-<h1 class="page-header" align="center">#<?=$problem['id']?> : <?=$problem['title']?> 管理</h1>
+<h1 align="center">#<?=$problem['id']?> : <?=$problem['title']?> 管理</h1>
 <ul class="nav nav-tabs" role="tablist">
 	<li><a href="/problem/<?= $problem['id'] ?>/manage/statement" role="tab">编辑</a></li>
 	<li><a href="/problem/<?= $problem['id'] ?>/manage/managers" role="tab">管理者</a></li>

--- a/app/controllers/problem_managers_manage.php
+++ b/app/controllers/problem_managers_manage.php
@@ -49,7 +49,7 @@
 	$visibility_form->runAtServer();
 ?>
 <?php echoUOJPageHeader(HTML::stripTags($problem['title']) . ' - 管理者 - 题目管理') ?>
-<h1 class="page-header" align="center">#<?=$problem['id']?> : <?=$problem['title']?> 管理</h1>
+<h1 align="center">#<?=$problem['id']?> : <?=$problem['title']?> 管理</h1>
 <ul class="nav nav-tabs" role="tablist">
 	<li><a href="/problem/<?= $problem['id'] ?>/manage/statement" role="tab">编辑</a></li>
 	<li class="active"><a href="/problem/<?= $problem['id'] ?>/manage/managers" role="tab">管理者</a></li>

--- a/app/controllers/problem_statement_manage.php
+++ b/app/controllers/problem_statement_manage.php
@@ -51,7 +51,7 @@
 	$problem_editor->runAtServer();
 ?>
 <?php echoUOJPageHeader(HTML::stripTags($problem['title']) . ' - 编辑 - 题目管理') ?>
-<h1 class="page-header" align="center">#<?=$problem['id']?> : <?=$problem['title']?> 管理</h1>
+<h1 align="center">#<?=$problem['id']?> : <?=$problem['title']?> 管理</h1>
 <ul class="nav nav-tabs" role="tablist">
 	<li class="active"><a href="/problem/<?= $problem['id'] ?>/manage/statement" role="tab">编辑</a></li>
 <?php if (hasProblemPermission(Auth::user(), $problem)) { ?>

--- a/app/controllers/problem_statistics.php
+++ b/app/controllers/problem_statistics.php
@@ -62,7 +62,7 @@
 ?>
 <?php echoUOJPageHeader(HTML::stripTags($problem['title']) . ' - ' . UOJLocale::get('problems::statistics')) ?>
 
-<h1 class="page-header text-center"><?= $problem['title'] ?> <?= UOJLocale::get('problems::statistics') ?></h1>
+<h1 class="text-center"><?= $problem['title'] ?> <?= UOJLocale::get('problems::statistics') ?></h1>
 
 <?php if ($contest && !hasContestPermission(Auth::user(), $contest) && $contest['cur_progress'] <= CONTEST_IN_PROGRESS) { ?>
 <h2 class="text-center text-muted">比赛尚未结束</h2>

--- a/app/controllers/register.php
+++ b/app/controllers/register.php
@@ -80,7 +80,7 @@
 	$REQUIRE_LIB['dialog'] = '';
 ?>
 <?php echoUOJPageHeader(UOJLocale::get('register')) ?>
-<h2 class="page-header"><?= UOJLocale::get('register') ?></h2>
+<h2><?= UOJLocale::get('register') ?></h2>
 <form id="form-register" class="form-horizontal">
 	<div id="div-username" class="form-group">
 		<label for="input-username" class="col-sm-2 control-label"><?= UOJLocale::get('username') ?></label>

--- a/app/controllers/reset_pw.php
+++ b/app/controllers/reset_pw.php
@@ -18,7 +18,7 @@
 		$user = queryUser($username);
 		if ($user == null) {
 			return '不明错误';
-	}
+		}
 		if ($check_code !== md5($user['username'] . '+' . $user['password'])) {
 			return '不明错误';
 		}
@@ -29,13 +29,27 @@
 	if (isset($_POST['reset'])) {
 		die(resetPassword());
 	}
+	list($username, $check_code) = explode('.', base64url_decode($_GET['p']));
+	if (!isset($username) || !validateUsername($username)) {
+		become404Page();
+	}
+	if (!isset($check_code)) {
+		become404Page();
+	}
+	$user = queryUser($username);
+	if ($user == null) {
+		become404Page();
+	}
+	if ($check_code !== md5($user['username'] . '+' . $user['password'])) {
+		become404Page();
+	}
 ?>
 <?php
 	$REQUIRE_LIB['dialog'] = '';
 	$REQUIRE_LIB['md5'] = '';
 ?>
 <?php echoUOJPageHeader(UOJLocale::get('reset password')) ?>
-<h2 class="page-header"><?= UOJLocale::get('reset password') ?></h2>
+<h2><?= UOJLocale::get('reset password') ?></h2>
 <form id="form-reset" class="form-horizontal">
 	<div id="div-password" class="form-group">
 		<label for="input-password" class="col-sm-2 control-label"><?= UOJLocale::get('new password') ?></label>

--- a/app/controllers/user_msg.php
+++ b/app/controllers/user_msg.php
@@ -80,7 +80,7 @@
 ?>
 <?php echoUOJPageHeader(UOJLocale::get('private message')) ?>
 
-<h1 class="page-header"><?= UOJLocale::get('private message') ?></h1>
+<h1><?= UOJLocale::get('private message') ?></h1>
 
 <div id="conversations">
 </div>

--- a/app/locale/problems/en.php
+++ b/app/locale/problems/en.php
@@ -49,5 +49,10 @@ return [
 	'estimate result' => 'Estimate Result',
 	'view problem' => 'View problem',
 	'problem visibility' => 'Problem visibility',
-	'back to list' => 'Go to problemset'
+	'back to list' => 'Go to problemset',
+	'attachments' => 'Attachments',
+	'output only' => 'Output only',
+	'interactive' => 'Interactive',
+	'custom checker' => 'Custom checker',
+	'custom judger' => 'Custom judger',
 ];

--- a/app/locale/problems/zh-cn.php
+++ b/app/locale/problems/zh-cn.php
@@ -49,5 +49,10 @@ return [
 	'estimate result' => '预估结果',
 	'view problem' => '查看题目',
 	'problem visibility' => '题目可见性',
-	'back to list' => '转到题库'
+	'back to list' => '转到题库',
+	'attachments' => '下发文件',
+	'output only' => '答案提交题',
+	'interactive' => '交互式程序题',
+	'custom checker' => '自定义答案检查器',
+	'custom judger' => '自定义测评器',
 ];

--- a/app/models/HTML.php
+++ b/app/models/HTML.php
@@ -67,8 +67,12 @@ class HTML {
 			$param = array_merge($param, $config['params']);
 		}
 		
-		//$url = UOJConfig::$data['web'][$config['location']]['protocol'].'://'.UOJConfig::$data['web'][$config['location']]['host'];
-		$url = '';
+		if (isset($config['absolute'])) {
+			$url = UOJConfig::$data['web'][$config['location']]['protocol'].'://'.UOJConfig::$data['web'][$config['location']]['host'];
+		}
+		else {
+			$url = '';
+		}
 		if (UOJConfig::$data['web'][$config['location']]['port'] != 80) {
 			$url .= ':' . UOJConfig::$data['web'][$config['location']]['port'];
 		}


### PR DESCRIPTION
Remove `page-header` class from some pages.

Remove cookies for estimated score.

`HTML::url` returns absolute path (as it used to do) if `$config['absolute']` is set. It is used in password-reseting mails.

Show an attachments tab for problems with attachments.

Show problem configures like judger, checker, limit of time and memory, and some special configures like `submit_answer`, `with_implementer`, `interaction_mode`.