### PR TITLE
Support problem_creator.

### DIFF
--- a/app/controllers/download.php
+++ b/app/controllers/download.php
@@ -35,7 +35,7 @@
 			}
 
 			$id = $_GET['id'];
-			insertAuditLog('problems','download attachments',$id,isset($_GET['reason'])?$_GET['reason']:'','');
+			insertAuditLog('problems','download attachments',$id,isset($_GET['reason'])?substr($_GET['reason'], 0, 100):'','');
 			
 			$file_name = "/var/uoj_data/{$id}/download.zip";
 			$download_name = "problem_{$id}.zip";

--- a/app/controllers/download.php
+++ b/app/controllers/download.php
@@ -35,7 +35,7 @@
 			}
 
 			$id = $_GET['id'];
-			insertAuditLog('problems','download attachments',$id,isset($_GET['reason'])?substr($_GET['reason'], 0, 100):'','');
+			insertAuditLog('problems','download attachments',$id,isset($_GET['reason'])?mb_substr($_GET['reason'], 0, 100):'','');
 			
 			$file_name = "/var/uoj_data/{$id}/download.zip";
 			$download_name = "problem_{$id}.zip";
@@ -73,7 +73,7 @@
 			}
 
 			$id = $_GET['id'];
-			insertAuditLog('problems','download data',$id,isset($_GET['reason'])?$_GET['reason']:'','');
+			insertAuditLog('problems','download data',$id,isset($_GET['reason'])?mb_substr($_GET['reason'], 0, 100):'','');
 			$file_name = "/var/uoj_data/{$id}.zip";
 			$download_name = "data_{$id}.zip";
 			break;

--- a/app/controllers/download.php
+++ b/app/controllers/download.php
@@ -35,6 +35,7 @@
 			}
 
 			$id = $_GET['id'];
+			insertAuditLog('problems','download attachments',$id,isset($_GET['reason'])?$_GET['reason']:'','');
 			
 			$file_name = "/var/uoj_data/{$id}/download.zip";
 			$download_name = "problem_{$id}.zip";
@@ -72,6 +73,7 @@
 			}
 
 			$id = $_GET['id'];
+			insertAuditLog('problems','download data',$id,isset($_GET['reason'])?$_GET['reason']:'','');
 			$file_name = "/var/uoj_data/{$id}.zip";
 			$download_name = "data_{$id}.zip";
 			break;

--- a/app/controllers/problem_data_manage.php
+++ b/app/controllers/problem_data_manage.php
@@ -2,6 +2,7 @@
 	requirePHPLib('form');
 	requirePHPLib('judger');
 	requirePHPLib('data');
+	requirePHPLib('problem');
 
 	if (!validateUInt($_GET['id']) || !($problem = queryProblemBrief($_GET['id']))) {
 		become404Page();

--- a/app/controllers/problem_data_manage.php
+++ b/app/controllers/problem_data_manage.php
@@ -183,19 +183,8 @@ EOD
 			if ($problem['data_locked']) {
 				becomeMsgPage('<div>Problem data locked.</div><a href="/problem/' . $problem['id'] . '/manage/data">返回</a>');
 			}
-			insertAuditLog('problems','update submission_requirement',$problem['id'],'',
-				json_encode(
-					array('config' => json_decode($vdata['submission_requirement'], true))
-				)
-			);
-			insertAuditLog('problems','update extra_config',$problem['id'],'',
-				json_encode(
-					array('config' => json_decode($vdata['extra_config'], true))
-				)
-			);
-			$esc_submission_requirement = DB::escape($vdata['submission_requirement']);
-			$esc_extra_config = DB::escape($vdata['extra_config']);
-			DB::update("update problems set submission_requirement = '$esc_submission_requirement', extra_config = '$esc_extra_config' where id = {$problem['id']}");
+			dataUpdateSubmissionRequirement($problem['id'], $vdata['submission_requirement']);
+			updateProblemExtraConfig($problem['id'], $vdata['extra_config']);
 		};
 	}
 	class DataDisplayer {

--- a/app/controllers/problem_data_manage.php
+++ b/app/controllers/problem_data_manage.php
@@ -575,11 +575,7 @@ EOD
 		$config['view_content_type'] = $_POST['view_content_type'];
 		$config['view_all_details_type'] = $_POST['view_all_details_type'];
 		$config['view_details_type'] = $_POST['view_details_type'];
-		insertAuditLog('problems','update extra_config',$problem['id'],'',json_encode(
-					array('config' => $config)
-				));
-		$esc_config = DB::escape(json_encode($config));
-		DB::update("update problems set extra_config = '$esc_config' where id = '{$problem['id']}'");
+		updateProblemExtraConfig($problem['id'], json_encode($config));
 	};
 	$view_type_form->submit_button_config['class_str'] = 'btn btn-warning btn-block top-buffer-sm';
 	

--- a/app/controllers/problem_data_manage.php
+++ b/app/controllers/problem_data_manage.php
@@ -185,12 +185,12 @@ EOD
 			}
 			insertAuditLog('problems','update submission_requirement',$problem['id'],'',
 				json_encode(
-					array('config' => $vdata['submission_requirement'])
+					array('config' => json_decode($vdata['submission_requirement'], true))
 				)
 			);
 			insertAuditLog('problems','update extra_config',$problem['id'],'',
 				json_encode(
-					array('config' => $vdata['extra_config'])
+					array('config' => json_decode($vdata['extra_config'], true))
 				)
 			);
 			$esc_submission_requirement = DB::escape($vdata['submission_requirement']);

--- a/app/controllers/problem_managers_manage.php
+++ b/app/controllers/problem_managers_manage.php
@@ -1,6 +1,7 @@
 <?php
 	requirePHPLib('form');
 	requirePHPLib('data');
+	requirePHPLib('problem');
 
 	if (!validateUInt($_GET['id']) || !($problem = queryProblemBrief($_GET['id']))) {
 		become404Page();

--- a/app/controllers/problem_managers_manage.php
+++ b/app/controllers/problem_managers_manage.php
@@ -20,9 +20,9 @@
 		function($type, $username) {
 			global $problem;
 			if ($type === '+') {
-				DB::insert("insert into problems_permissions (problem_id, username) values ({$problem['id']}, '$username')");
+				addProblemPermission($problem['id'], $username);
 			} else if ($type === '-') {
-				DB::delete("delete from problems_permissions where problem_id = {$problem['id']} and username = '$username'");
+				deleteProblemPermission($problem['id'], $username);
 			}
 		}
 	);
@@ -39,9 +39,9 @@
 		function($type, $groupname) {
 			global $problem;
 			if ($type === '+') {
-				DB::insert("insert into problems_visibility (problem_id, group_name) values ({$problem['id']}, '$groupname')");
+				addProblemViewPermission($problem['id'], $groupname);
 			} else if ($type === '-') {
-				DB::delete("delete from problems_visibility where problem_id = {$problem['id']} and group_name = '$groupname'");
+				deleteProblemViewPermission($problem['id'], $groupname);
 			}
 		}
 	);

--- a/app/controllers/problem_set.php
+++ b/app/controllers/problem_set.php
@@ -196,7 +196,7 @@ EOD;
 	</div>
 </div>
 <?php
-	if (isProblemManager(Auth::user())) {
+	if (isProblemCreator(Auth::user())) {
 		$new_problem_form->printHTML();
 	}
 ?>

--- a/app/controllers/problem_set.php
+++ b/app/controllers/problem_set.php
@@ -7,9 +7,10 @@
 		redirectToLogin();
 	}
 
-	if (isProblemManager(Auth::user())) {
+	if (isProblemCreator(Auth::user())) {
 		$new_problem_form = new UOJForm('new_problem');
 		$new_problem_form->handle = function() {
+			insertAuditLog('problems','create',$problem['id'],'','');
 			DB::insert("insert into problems (title, is_hidden, submission_requirement) values ('New Problem', 1, '{}')");
 			$id = DB::insert_id();
 			DB::insert("insert into problems_contents (id, statement, statement_md) values ({$id}, '', '')");

--- a/app/controllers/problem_set.php
+++ b/app/controllers/problem_set.php
@@ -10,11 +10,14 @@
 	if (isProblemCreator(Auth::user())) {
 		$new_problem_form = new UOJForm('new_problem');
 		$new_problem_form->handle = function() {
-			insertAuditLog('problems','create',$problem['id'],'','');
 			DB::insert("insert into problems (title, is_hidden, submission_requirement) values ('New Problem', 1, '{}')");
 			$id = DB::insert_id();
+			insertAuditLog('problems','create',$id,'','');
 			DB::insert("insert into problems_contents (id, statement, statement_md) values ({$id}, '', '')");
 			DB::insert("insert into problems_visibility (problem_id, group_name) values ({$id}, '" . UOJConfig::$data['profile']['common-group'] . "')");
+			if (!isProblemManager(Auth::user())) {
+				DB::insert("insert into problems_permissions (problem_id, username) values ({$id}, '" . Auth::id() . "')");
+			}
 			dataNewProblem($id);
 		};
 		$new_problem_form->submit_button_config['align'] = 'right';

--- a/app/controllers/problem_set.php
+++ b/app/controllers/problem_set.php
@@ -2,6 +2,7 @@
 	requirePHPLib('form');
 	requirePHPLib('judger');
 	requirePHPLib('data');
+	requirePHPLib('problem');
 
 	if (!Auth::check()) {
 		redirectToLogin();
@@ -10,15 +11,7 @@
 	if (isProblemCreator(Auth::user())) {
 		$new_problem_form = new UOJForm('new_problem');
 		$new_problem_form->handle = function() {
-			DB::insert("insert into problems (title, is_hidden, submission_requirement) values ('New Problem', 1, '{}')");
-			$id = DB::insert_id();
-			insertAuditLog('problems','create',$id,'','');
-			DB::insert("insert into problems_contents (id, statement, statement_md) values ({$id}, '', '')");
-			DB::insert("insert into problems_visibility (problem_id, group_name) values ({$id}, '" . UOJConfig::$data['profile']['common-group'] . "')");
-			if (!isProblemManager(Auth::user())) {
-				DB::insert("insert into problems_permissions (problem_id, username) values ({$id}, '" . Auth::id() . "')");
-			}
-			dataNewProblem($id);
+			newProblem();
 		};
 		$new_problem_form->submit_button_config['align'] = 'right';
 		$new_problem_form->submit_button_config['class_str'] = 'btn btn-primary';

--- a/app/uoj-data-lib.php
+++ b/app/uoj-data-lib.php
@@ -363,6 +363,35 @@
 		return (new SyncProblemDataHandler($problem, $permission_level, array('no_compile' => '')))->handle($log_config);
 	}
 
+	function dataFlipHackableStatus($problem, $log_config = array()) {
+		$problem['hackable'] = !$problem['hackable'];
+		insertAuditLog('problems','flip hackable-status',$problem['id'],isset($log_config['reason'])?$log_config['reason']:'',
+			json_encode(
+				array('hackable-status' => ($problem['hackable'] ? 1 : 0))
+			), $log_config);
+		$ret = dataSyncProblemData($problem, (bool)isSuperUser(Auth::user()), array('reason' => 'flip hackable-status', 'auto' => true));
+		if ($ret) {
+			insertAuditLog('problems','flip hackable-status failed',$problem['id'],'',json_encode(
+				array('final hackable-status' => ($problem['hackable'] ? 0 : 1), 'exception_message' => $ret)
+			), array('auto' => true));
+			return ret;
+		}
+		
+		$hackable = $problem['hackable'] ? 1 : 0;
+		DB::update("update problems set hackable = $hackable where id = {$problem['id']}");
+		return ret;
+	}
+
+	function dataFlipLockedStatus($problem, $log_config = array()) {
+		$problem['data_locked'] = !$problem['data_locked'];
+		$hackable = $problem['data_locked'] ? 1 : 0;
+		insertAuditLog('problems','flip data-locked-status',$problem['id'],isset($log_config['reason'])?$log_config['reason']:'',
+			json_encode(
+				array('data-locked-status' => $hackable)
+			), $log_config);
+		DB::update("update problems set data_locked = $hackable where id = {$problem['id']}");
+	}
+
 	function dataAddExtraTest($problem, $input_file_name, $output_file_name, $log_config=array()) {
 		$id = $problem['id'];
 		

--- a/app/uoj-data-lib.php
+++ b/app/uoj-data-lib.php
@@ -374,12 +374,12 @@
 			insertAuditLog('problems','flip hackable-status failed',$problem['id'],'',json_encode(
 				array('final hackable-status' => ($problem['hackable'] ? 0 : 1), 'exception_message' => $ret)
 			), array('auto' => true));
-			return ret;
+			return $ret;
 		}
 		
 		$hackable = $problem['hackable'] ? 1 : 0;
 		DB::update("update problems set hackable = $hackable where id = {$problem['id']}");
-		return ret;
+		return $ret;
 	}
 
 	function dataFlipLockedStatus($problem, $log_config = array()) {

--- a/app/uoj-data-lib.php
+++ b/app/uoj-data-lib.php
@@ -33,6 +33,15 @@
 		exec("rm /var/uoj_data/$id -r");
 		dataNewProblem($id);
 	}
+
+	function dataUpdateSubmissionRequirement($problem_id, $config_json, $log_config) {
+		insertAuditLog('problems', 'update submission_requirement', $problem_id, isset($log_config['reason'])?$log_config['reason']:'',
+			json_encode(
+				array('config' => json_decode($config_json, true))
+			),
+		$log_config);
+		DB::update("update problems set submission_requirement = '" . DB::escape($config_json) . "' where id = $problem_id");
+	}
 	
 	class SyncProblemDataHandler {
 		private $problem, $permission_level, $sync_config;
@@ -324,8 +333,7 @@
 
 				$orig_requirement = json_decode($this->problem['submission_requirement'], true);
 				if (!$orig_requirement) {
-					$esc_requirement = DB::escape(json_encode($this->requirement));
-					DB::update("update problems set submission_requirement = '$esc_requirement' where id = $id");
+					dataUpdateSubmissionRequirement($id, json_encode($this->requirement), array('reason' => 'data preparing', 'auto' => true));
 				}
 			} catch (Exception $e) {
 				insertAuditLog('problems','data preparing failed',$id,'',json_encode(

--- a/app/uoj-data-lib.php
+++ b/app/uoj-data-lib.php
@@ -34,7 +34,7 @@
 		dataNewProblem($id);
 	}
 
-	function dataUpdateSubmissionRequirement($problem_id, $config_json, $log_config) {
+	function dataUpdateSubmissionRequirement($problem_id, $config_json, $log_config = array()) {
 		insertAuditLog('problems', 'update submission_requirement', $problem_id, isset($log_config['reason'])?$log_config['reason']:'',
 			json_encode(
 				array('config' => json_decode($config_json, true))

--- a/app/uoj-form-lib.php
+++ b/app/uoj-form-lib.php
@@ -633,7 +633,7 @@ EOD;
 			if (isset($this->submit_button_config['reason'])) {
 				global $action_reason;
 				if (isset($_POST["{$this->form_name}-reason"])) {
-					$action_reason = substr($_POST["{$this->form_name}-reason"], 0, 100);
+					$action_reason = mb_substr($_POST["{$this->form_name}-reason"], 0, 100);
 				}
 				else {
 					$action_reason = null;

--- a/app/uoj-form-lib.php
+++ b/app/uoj-form-lib.php
@@ -540,8 +540,12 @@ EOD;
 			if (isset($this->submit_button_config['confirm_text'])) {
 				if (isset($this->submit_button_config['reason'])) {
 				echo <<<EOD
-		const res = prompt('{$this->submit_button_config['confirm_text']}\\n备注（选填）：');
+		const res = prompt('{$this->submit_button_config['confirm_text']}\\n原因（选填，不超过 100 字）：');
 		if (res === null) {
+			ok = false;
+		}
+		else  if (res.length > 100) {
+			alert('原因过长！');
 			ok = false;
 		}
 		else {

--- a/app/uoj-group-lib.php
+++ b/app/uoj-group-lib.php
@@ -21,6 +21,10 @@ function isProblemManager($user) {
 	return isSuperUser($user) or isGroupMember($user, array('group_name' => 'problem_manager'));
 }
 
+function isProblemCreator($user) {
+	return isProblemManager($user) or isGroupMember($user, array('group_name' => 'problem_creator'));
+}
+
 function isStatementMaintainer($user) {
 	return isGroupMember($user, array('group_name' => 'statement_maintainer'));
 }

--- a/app/uoj-html-lib.php
+++ b/app/uoj-html-lib.php
@@ -722,6 +722,18 @@ function echoProblemAuditLog($audit_log) {
 			case 'flip data-locked-status':
 				$mes['title'] = $title_author_prefix . ($log_now['details']['data-locked-status'] ? '锁定' : '解锁') . '该题数据';
 				break;
+			case 'download attachments':
+				if (isSuperUser(Auth::user()))
+					$mes['title'] = '下载下发文件';
+				else
+					$no_message = true;
+				break;
+			case 'download data':
+				if (isSuperUser(Auth::user()))
+					$mes['title'] = '下载数据';
+				else
+					$no_message = true;
+				break;
 			default:
 				++$unrecognized_cnt;
 				$no_message = true;

--- a/app/uoj-html-lib.php
+++ b/app/uoj-html-lib.php
@@ -718,7 +718,7 @@ function echoProblemAuditLog($audit_log) {
 				if (isSuperUser(Auth::user())) {
 					if (!isset($mes['previous_list']))
 						$mes['previous_list'] = array();
-					$mes['previous_list'][] = '<strong>配置：</strong>' . HTML::escape($log_now['details']['config']);
+					$mes['previous_list'][] = '<strong>配置：</strong>' . HTML::escape(json_encode($log_now['details']['config']));
 				}
 				break;
 			case 'update extra_config':
@@ -726,7 +726,7 @@ function echoProblemAuditLog($audit_log) {
 				if (isSuperUser(Auth::user())) {
 					if (!isset($mes['previous_list']))
 						$mes['previous_list'] = array();
-					$mes['previous_list'][] = '<strong>配置：</strong>' . HTML::escape($log_now['details']['config']);
+					$mes['previous_list'][] = '<strong>配置：</strong>' . HTML::escape(json_encode($log_now['details']['config']));
 				}
 				break;
 			case 'flip data-locked-status':

--- a/app/uoj-html-lib.php
+++ b/app/uoj-html-lib.php
@@ -611,6 +611,10 @@ function echoProblemAuditLog($audit_log) {
 						if ($log_now['reason'] == 'successful hack')
 							$display_reason = false;
 						break;
+					case 'add permission':
+						if ($log_now['reason'] == 'create problem without manage permission')
+							$log_now['reason'] = '无管理权限用户添加新题';
+						break;
 				}
 			}
 			if ($display_reason) {

--- a/app/uoj-html-lib.php
+++ b/app/uoj-html-lib.php
@@ -718,7 +718,7 @@ function echoProblemAuditLog($audit_log) {
 				if (isSuperUser(Auth::user())) {
 					if (!isset($mes['previous_list']))
 						$mes['previous_list'] = array();
-					$mes['previous_list'][] = '<strong>配置：</strong>' . HTML::escape(json_encode($log_now['details']['config']));
+					$mes['previous_list'][] = '<strong>配置：</strong>' . HTML::escape($log_now['details']['config']);
 				}
 				break;
 			case 'update extra_config':
@@ -726,7 +726,7 @@ function echoProblemAuditLog($audit_log) {
 				if (isSuperUser(Auth::user())) {
 					if (!isset($mes['previous_list']))
 						$mes['previous_list'] = array();
-					$mes['previous_list'][] = '<strong>配置：</strong>' . HTML::escape(json_encode($log_now['details']['config']));
+					$mes['previous_list'][] = '<strong>配置：</strong>' . HTML::escape($log_now['details']['config']);
 				}
 				break;
 			case 'flip data-locked-status':

--- a/app/uoj-html-lib.php
+++ b/app/uoj-html-lib.php
@@ -632,7 +632,7 @@ function echoProblemAuditLog($audit_log) {
 				if (isSuperUser(Auth::user())) {
 					if (!isset($mes['previous_list']))
 						$mes['previous_list'] = array();
-					$mes['previous_list'][] = '<span><strong>操作对象：</strong>' . getUserLink($log_now['details']['username']) . '</span>;
+					$mes['previous_list'][] = '<span><strong>操作对象：</strong>' . getUserLink($log_now['details']['username']) . '</span>';
 				}
 				break;
 			case 'delete permission':
@@ -640,7 +640,7 @@ function echoProblemAuditLog($audit_log) {
 				if (isSuperUser(Auth::user())) {
 					if (!isset($mes['previous_list']))
 						$mes['previous_list'] = array();
-					$mes['previous_list'][] = '<span><strong>操作对象：</strong>' . getUserLink($log_now['details']['username']) . '</span>;
+					$mes['previous_list'][] = '<span><strong>操作对象：</strong>' . getUserLink($log_now['details']['username']) . '</span>';
 				}
 				break;
 			case 'add view permission':
@@ -648,7 +648,7 @@ function echoProblemAuditLog($audit_log) {
 				if (isSuperUser(Auth::user())) {
 					if (!isset($mes['previous_list']))
 						$mes['previous_list'] = array();
-					$mes['previous_list'][] = '<span><strong>操作对象：</strong>' . getGroupLink($log_now['details']['groupname']) . '</span>;
+					$mes['previous_list'][] = '<span><strong>操作对象：</strong>' . getGroupLink($log_now['details']['groupname']) . '</span>';
 				}
 				break;
 			case 'delete view permission':
@@ -656,7 +656,7 @@ function echoProblemAuditLog($audit_log) {
 				if (isSuperUser(Auth::user())) {
 					if (!isset($mes['previous_list']))
 						$mes['previous_list'] = array();
-					$mes['previous_list'][] = '<span><strong>操作对象：</strong>' . getGroupLink($log_now['details']['groupname']) . '</span>;
+					$mes['previous_list'][] = '<span><strong>操作对象：</strong>' . getGroupLink($log_now['details']['groupname']) . '</span>';
 				}
 				break;
 			case 'rejudge':

--- a/app/uoj-html-lib.php
+++ b/app/uoj-html-lib.php
@@ -624,6 +624,41 @@ function echoProblemAuditLog($audit_log) {
 				$mes['title'] = '当前题目状态';
 				// $mes['uri'] = ;
 				break;
+			case 'create':
+				$mes['title'] = '新建该题';
+				break;
+			case 'add permission':
+				$mes['title'] = $title_author_prefix . '添加了一个管理者';
+				if (isSuperUser(Auth::user())) {
+					if (!isset($mes['previous_list']))
+						$mes['previous_list'] = array();
+					$mes['previous_list'][] = '<span><strong>操作对象：</strong>' . getUserLink($log_now['details']['username']) . '</span>;
+				}
+				break;
+			case 'delete permission':
+				$mes['title'] = $title_author_prefix . '删除了一个管理者';
+				if (isSuperUser(Auth::user())) {
+					if (!isset($mes['previous_list']))
+						$mes['previous_list'] = array();
+					$mes['previous_list'][] = '<span><strong>操作对象：</strong>' . getUserLink($log_now['details']['username']) . '</span>;
+				}
+				break;
+			case 'add view permission':
+				$mes['title'] = $title_author_prefix . '添加了一个可见组';
+				if (isSuperUser(Auth::user())) {
+					if (!isset($mes['previous_list']))
+						$mes['previous_list'] = array();
+					$mes['previous_list'][] = '<span><strong>操作对象：</strong>' . getGroupLink($log_now['details']['groupname']) . '</span>;
+				}
+				break;
+			case 'delete view permission':
+				$mes['title'] = $title_author_prefix . '删除了一个可见组';
+				if (isSuperUser(Auth::user())) {
+					if (!isset($mes['previous_list']))
+						$mes['previous_list'] = array();
+					$mes['previous_list'][] = '<span><strong>操作对象：</strong>' . getGroupLink($log_now['details']['groupname']) . '</span>;
+				}
+				break;
 			case 'rejudge':
 			case 'rejudge Ge97':
 			case 'rejudge AC':
@@ -673,6 +708,9 @@ function echoProblemAuditLog($audit_log) {
 				break;
 			case 'data uploading':
 				$mes['title'] = $title_author_prefix . '上传该题数据';
+				break;
+			case 'update submission_requirement':
+				$mes['title'] = $title_author_prefix . '修改该题提交文件配置';
 				break;
 			case 'update extra_config':
 				$mes['title'] = $title_author_prefix . '修改该题额外配置';

--- a/app/uoj-html-lib.php
+++ b/app/uoj-html-lib.php
@@ -715,9 +715,19 @@ function echoProblemAuditLog($audit_log) {
 				break;
 			case 'update submission_requirement':
 				$mes['title'] = $title_author_prefix . '修改该题提交文件配置';
+				if (isSuperUser(Auth::user())) {
+					if (!isset($mes['previous_list']))
+						$mes['previous_list'] = array();
+					$mes['previous_list'][] = '<strong>配置：</strong>' . HTML::escape(json_encode($log_now['details']['config']));
+				}
 				break;
 			case 'update extra_config':
 				$mes['title'] = $title_author_prefix . '修改该题额外配置';
+				if (isSuperUser(Auth::user())) {
+					if (!isset($mes['previous_list']))
+						$mes['previous_list'] = array();
+					$mes['previous_list'][] = '<strong>配置：</strong>' . HTML::escape(json_encode($log_now['details']['config']));
+				}
 				break;
 			case 'flip data-locked-status':
 				$mes['title'] = $title_author_prefix . ($log_now['details']['data-locked-status'] ? '锁定' : '解锁') . '该题数据';

--- a/app/uoj-html-lib.php
+++ b/app/uoj-html-lib.php
@@ -615,6 +615,10 @@ function echoProblemAuditLog($audit_log) {
 						if ($log_now['reason'] == 'create problem without manage permission')
 							$log_now['reason'] = '无管理权限用户添加新题';
 						break;
+					case 'update submission_requirement':
+						if ($log_now['reason'] == 'data preparing')
+							$log_now['reason'] = '数据预处理操作';
+						break;
 				}
 			}
 			if ($display_reason) {

--- a/app/uoj-problem-lib.php
+++ b/app/uoj-problem-lib.php
@@ -1,0 +1,22 @@
+<?php
+	requirePHPLib('data');
+
+	function addProblemPermission($problem_id, $username, $log_config = array()) {
+		insertAuditLog('problems','add permission',$problem_id,isset($log_config['reason'])?$log_config['reason']:'', json_encode(array('username' => $username)), $log_config);
+		DB::insert("insert into problems_permissions (problem_id, username) values ({$problem_id}, '$username')");
+	}
+	function deleteProblemPermission($problem_id, $username, $log_config = array()) {
+		insertAuditLog('problems','delete permission',$problem_id,isset($log_config['reason'])?$log_config['reason']:'', json_encode(array('username' => $username)), $log_config);
+		DB::delete("delete from problems_permissions where problem_id = {$problem_id} and username = '$username'");
+	}
+	function newProblem($log_config = array()) {
+		DB::insert("insert into problems (title, is_hidden, submission_requirement) values ('New Problem', 1, '{}')");
+		$id = DB::insert_id();
+		insertAuditLog('problems','create',$id,isset($log_config['reason'])?$log_config['reason']:'', '', $log_config);
+		DB::insert("insert into problems_contents (id, statement, statement_md) values ({$id}, '', '')");
+		DB::insert("insert into problems_visibility (problem_id, group_name) values ({$id}, '" . UOJConfig::$data['profile']['common-group'] . "')");
+		if (!isProblemManager(Auth::user()))
+			addProblemPermission($id, Auth::id(), array('reason' => 'create problem without manage permission', 'auto' => true));
+		dataNewProblem($id);
+		return $id;
+	}

--- a/app/uoj-problem-lib.php
+++ b/app/uoj-problem-lib.php
@@ -1,5 +1,5 @@
 <?php
-	requirePHPLib('data');
+	// need `requirePHPLib('data');`
 
 	function addProblemPermission($problem_id, $username, $log_config = array()) {
 		insertAuditLog('problems','add permission',$problem_id,isset($log_config['reason'])?$log_config['reason']:'', json_encode(array('username' => $username)), $log_config);

--- a/app/uoj-problem-lib.php
+++ b/app/uoj-problem-lib.php
@@ -32,3 +32,12 @@
 		dataNewProblem($id);
 		return $id;
 	}
+
+	function updateProblemExtraConfig($problem_id, $config_json, $log_config = array()) {
+		insertAuditLog('problems', 'update extra_config', $problem_id, isset($log_config['reason'])?$log_config['reason']:'',
+			json_encode(
+				array('config' => json_decode($config_json, true))
+			),
+		$log_config);
+		DB::update("update problems set extra_config = '" . DB::escape($config_json) . "' where id = $problem_id");
+	}

--- a/app/uoj-problem-lib.php
+++ b/app/uoj-problem-lib.php
@@ -5,10 +5,22 @@
 		insertAuditLog('problems','add permission',$problem_id,isset($log_config['reason'])?$log_config['reason']:'', json_encode(array('username' => $username)), $log_config);
 		DB::insert("insert into problems_permissions (problem_id, username) values ({$problem_id}, '$username')");
 	}
+
 	function deleteProblemPermission($problem_id, $username, $log_config = array()) {
 		insertAuditLog('problems','delete permission',$problem_id,isset($log_config['reason'])?$log_config['reason']:'', json_encode(array('username' => $username)), $log_config);
 		DB::delete("delete from problems_permissions where problem_id = {$problem_id} and username = '$username'");
 	}
+
+	function addProblemViewPermission($problem_id, $groupname, $log_config = array()) {
+		insertAuditLog('problems','add view permission',$problem_id,isset($log_config['reason'])?$log_config['reason']:'', json_encode(array('groupname' => $groupname)), $log_config);
+		DB::insert("insert into problems_visibility (problem_id, group_name) values ({$problem_id}, '$groupname')");
+	}
+
+	function deleteProblemViewPermission($problem_id, $groupname, $log_config = array()) {
+		insertAuditLog('problems','delete view permission',$problem_id,isset($log_config['reason'])?$log_config['reason']:'', json_encode(array('groupname' => $groupname)), $log_config);
+		DB::delete("delete from problems_visibility where problem_id = {$problem_id} and group_name = '$groupname'");
+	}
+
 	function newProblem($log_config = array()) {
 		DB::insert("insert into problems (title, is_hidden, submission_requirement) values ('New Problem', 1, '{}')");
 		$id = DB::insert_id();

--- a/update.md
+++ b/update.md
@@ -224,3 +224,9 @@ CREATE TABLE `removed_submissions` (
   KEY `contest_id` (`contest_id`,`problem_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 ```
+
+### update JUL 10 21:40
+
+```sql
+update group_info set group_type='S' where group_name='problem_creator';
+```


### PR DESCRIPTION
支持题目创建者创建新题，无原有题目管理权限，对应系统组 `problem_creator`，通过 `isProblemCreator` 判断。

在数据管理界面中，将上传数据按钮上移且添加了一些中英文间的空格。

记录下载下发文件与数据的日志，支持超管查看。

新建了 `uoj-problem-lib.php`。

封装了 `dataUpdateSubmissionRequirement` `updateProblemExtraConfig` 并记录日志。

封装了 `dataFlipHackableStatus` `dataFlipLockedStatus`。

封装了 `addProblemPermission` `deleteProblemPermission` `addProblemViewPermission` `deleteProblemViewPermission` `newProblem` 并记录日志。